### PR TITLE
Fix argon2i hash length to make shares valid.

### DIFF
--- a/miner.py
+++ b/miner.py
@@ -102,10 +102,10 @@ def solve_work(index, work_item, work_item_lock, result_queue, hash_rates):
         base = '%s-%s-%s-%s' % (pool_address, nonce, block, difficulty)
         if height > 10800:
             ph = argon2.PasswordHasher(
-                time_cost=1, memory_cost=524288, parallelism=1)
+                time_cost=1, memory_cost=524288, parallelism=1, hash_len=32)
         else:
             ph = argon2.PasswordHasher(
-                time_cost=4, memory_cost=16384, parallelism=4)
+                time_cost=4, memory_cost=16384, parallelism=4, hash_len=32)
         argon = ph.hash(base)
         base = base + argon
         hash = hashlib.sha512(base.encode('utf-8'))


### PR DESCRIPTION
The python argon2_cffi library uses a default hash length of 16 bytes (with a 16 byte salt).  This conflicts with the default in the PHP reference client (and the code the pool uses) which is a 32 byte hash with 16 byte salt.  

As such, shares made from the client would be considered invalid thusfar, resulting in the pool blocking further shares from the workers running this client.  This PR changes the parameters passed to the argon2 'PasswordHasher' constructor to set the length correctly to 32 bytes.